### PR TITLE
排版修正 ch4-2.md & ch4-3.md

### DIFF
--- a/content/ch4-2.md
+++ b/content/ch4-2.md
@@ -18,88 +18,93 @@ Example 4-2. Plain Variable Assignment
 
 >`範例 4-2. 普通的變數賦值`
 
-    #!/bin/bash
-    # Naked variables
-    # 裸體變數
 
-    echo
+```bash
+#!/bin/bash
+# Naked variables
+# 裸體變數
 
-    # When is a variable "naked", i.e., lacking the '$' in front?
-    # 變數何時為 "裸體" 的呢？也就是前面少個錢字號 '$' 的時候。
-    # When it is being assigned, rather than referenced.
-    # 當它被賦值而不是被參考的時候。
+echo
 
-    # Assignment
-    # 賦值：
-    a=879
-    echo "The value of \"a\" is $a."
+# When is a variable "naked", i.e., lacking the '$' in front?
+# 變數何時為 "裸體" 的呢？也就是前面少個錢字號 '$' 的時候。
+# When it is being assigned, rather than referenced.
+# 當它被賦值而不是被參考的時候。
 
-    # Assignment using 'let'
-    # 使用 'let' 賦值：
-    let a=16+5
-    echo "The value of \"a\" is now $a."
+# Assignment
+# 賦值：
+a=879
+echo "The value of \"a\" is $a."
 
-    echo
+# Assignment using 'let'
+# 使用 'let' 賦值：
+let a=16+5
+echo "The value of \"a\" is now $a."
 
-    # In a 'for' loop (really, a type of disguised assignment):
-    # 於 'for' 迴圈中 (真的啦，此為隱含賦值的一種型式)：
-    echo -n "Values of \"a\" in the loop are: "
-    for a in 7 8 9 11
-    do
-      echo -n "$a "
-    done
+echo
 
-    echo
-    echo
+# In a 'for' loop (really, a type of disguised assignment):
+# 於 'for' 迴圈中 (真的啦，此為隱含賦值的一種型式)：
+echo -n "Values of \"a\" in the loop are: "
+for a in 7 8 9 11
+do
+  echo -n "$a "
+done
 
-    # In a 'read' statement (also a type of assignment):
-    # 於 'read' 敘述 (這也是賦值的一種型式)：
-    echo -n "Enter \"a\" "
-    read a
-    echo "The value of \"a\" is now $a."
+echo
+echo
 
-    echo
+# In a 'read' statement (also a type of assignment):
+# 於 'read' 敘述 (這也是賦值的一種型式)：
+echo -n "Enter \"a\" "
+read a
+echo "The value of \"a\" is now $a."
 
-    exit 0
+echo
+
+exit 0
+```
 
 Example 4-3. Variable Assignment, plain and fancy
 
 >`範例 4-3. 普通的與花俏的變數賦值`
 
-    #!/bin/bash
-    a=23              # Simple case
-                      # 普通的例子
-    echo $a
-    b=$a
-    echo $b
+```bash
+#!/bin/bash
+a=23              # Simple case
+                  # 普通的例子
+echo $a
+b=$a
+echo $b
 
-    # Now, getting a little bit fancier (command substitution).
-    # 現在來點花俏的吧！ (指令替換(命令結果代換))
+# Now, getting a little bit fancier (command substitution).
+# 現在來點花俏的吧！ (指令替換(命令結果代換))
 
-    a=`echo Hello!`   # Assigns result of 'echo' command to 'a' ...
-                      # 'echo' 指令結果將賦值到 'a' ...
-    echo $a
-    # Note that including an exclamation mark (!) within a
-    #+ command substitution construct will not work from the command-line,
-    #+ since this triggers the Bash "history mechanism."
-    # Inside a script, however, the history functions are disabled by default.
-    # 注意：內含驚歎號 (!) 的指令替換結構在命令列上將會失效，
-    # 因為會觸發 Bash 的 "歷史機制"。
-    # 不過，在腳本裡面時，歷史功能預設是關閉的。
+a=`echo Hello!`   # Assigns result of 'echo' command to 'a' ...
+                  # 'echo' 指令結果將賦值到 'a' ...
+echo $a
+# Note that including an exclamation mark (!) within a
+#+ command substitution construct will not work from the command-line,
+#+ since this triggers the Bash "history mechanism."
+# Inside a script, however, the history functions are disabled by default.
+# 注意：內含驚歎號 (!) 的指令替換結構在命令列上將會失效，
+# 因為會觸發 Bash 的 "歷史機制"。
+# 不過，在腳本裡面時，歷史功能預設是關閉的。
 
-    a=`ls -l`         # Assigns result of 'ls -l' command to 'a'
-                      # 'ls -l' 指令結果將賦值到 'a'
-    echo $a           # Unquoted, however, it removes tabs and newlines.
-                      # 然而，若未使用引號包住，
-                      # 則變數值裡的 tabs (定位字元) 跟 newlines (換行字元) 將會被移除。
-    echo
-    echo "$a"         # The quoted variable preserves whitespace.
-                      # (See the chapter on "Quoting.")
-                      # 若有引號包住，則變數裡的空白字元將被保留 (含空格、定位、換行…等)。
-                      # (詳情請參照 "引號" 章節。)
+a=`ls -l`         # Assigns result of 'ls -l' command to 'a'
+                  # 'ls -l' 指令結果將賦值到 'a'
+echo $a           # Unquoted, however, it removes tabs and newlines.
+                  # 然而，若未使用引號包住，
+                  # 則變數值裡的 tabs (定位字元) 跟 newlines (換行字元) 將會被移除。
+echo
+echo "$a"         # The quoted variable preserves whitespace.
+                  # (See the chapter on "Quoting.")
+                  # 若有引號包住，則變數裡的空白字元將被保留 (含空格、定位、換行…等)。
+                  # (詳情請參照 "引號" 章節。)
 
 
-    exit 0
+exit 0
+```
 
 Variable assignment using the $(...) mechanism (a newer method than backquotes).
 
@@ -109,6 +114,8 @@ This is likewise a form of command substitution.
 
 >`同樣地這也是一種指令替換的型式。`
 
-    # From /etc/rc.d/rc.local
-    R=$(cat /etc/redhat-release)
-    arch=$(uname -m)
+```bash
+# From /etc/rc.d/rc.local
+R=$(cat /etc/redhat-release)
+arch=$(uname -m)
+```

--- a/content/ch4-3.md
+++ b/content/ch4-3.md
@@ -9,66 +9,68 @@ The determining factor is whether the value of a variable contains only digits.
 
 Example 4-4. Integer or string?
 
-    #!/bin/bash
-    # int-or-string.sh
+```bash
+#!/bin/bash
+# int-or-string.sh
 
-    a=2334                     # Integer.
-    let "a += 1"
-    echo "a = $a "             # a = 2335
-    echo                       # Integer, still.
+a=2334                     # Integer.
+let "a += 1"
+echo "a = $a "             # a = 2335
+echo                       # Integer, still.
 
-    b=${a/23/BB}               # Substitute "BB" for "23".
-                               # This transforms $b into a string.
-    echo "b = $b"              # b = BB35
-    declare -i b               # Declaring it an integer doesn't help.
-    echo "b = $b"              # b = BB35
+b=${a/23/BB}               # Substitute "BB" for "23".
+                           # This transforms $b into a string.
+echo "b = $b"              # b = BB35
+declare -i b               # Declaring it an integer doesn't help.
+echo "b = $b"              # b = BB35
 
-    let "b += 1"               # BB35 + 1
-    echo "b = $b"              # b = 1
-    echo                       # Bash sets the "integer value" of a string to 0.
+let "b += 1"               # BB35 + 1
+echo "b = $b"              # b = 1
+echo                       # Bash sets the "integer value" of a string to 0.
 
-    c=BB34
-    echo "c = $c"              # c = BB34
+c=BB34
+echo "c = $c"              # c = BB34
 
-    d=${c/BB/23}               # Substitute "23" for "BB".
-                               # This makes $d an integer.
-    echo "d = $d"              # d = 2334
-    let "d += 1"               # 2334 + 1
-    echo "d = $d"              # d = 2335
-    echo
+d=${c/BB/23}               # Substitute "23" for "BB".
+                           # This makes $d an integer.
+echo "d = $d"              # d = 2334
+let "d += 1"               # 2334 + 1
+echo "d = $d"              # d = 2335
+echo
 
-    # What about null variables?
-    e=''                       # ... Or e="" ... Or e=
-    echo "e = $e"              # e =
-    let "e += 1"               # Arithmetic operations allowed on a null variable?
-    echo "e = $e"              # e = 1
-    echo                       # Null variable transformed into an integer.
+# What about null variables?
+e=''                       # ... Or e="" ... Or e=
+echo "e = $e"              # e =
+let "e += 1"               # Arithmetic operations allowed on a null variable?
+echo "e = $e"              # e = 1
+echo                       # Null variable transformed into an integer.
 
-    # What about undeclared variables?
-    echo "f = $f"              # f =
-    let "f += 1"               # Arithmetic operations allowed?
-    echo "f = $f"              # f = 1
-    echo                       # Undeclared variable transformed into an integer.
-    #
-    # However ...
-    let "f /= $undecl_var"     # Divide by zero?
-    #   let: f /= : syntax error: operand expected (error token is "/= ")
-    # Syntax error! Variable $undecl_var is not set to zero here!
-    #
-    # But still ...
-    let "f /= 0"
-    #   let: f /= 0: division by 0 (error token is "0")
-    # Expected behavior.
+# What about undeclared variables?
+echo "f = $f"              # f =
+let "f += 1"               # Arithmetic operations allowed?
+echo "f = $f"              # f = 1
+echo                       # Undeclared variable transformed into an integer.
+#
+# However ...
+let "f /= $undecl_var"     # Divide by zero?
+#   let: f /= : syntax error: operand expected (error token is "/= ")
+# Syntax error! Variable $undecl_var is not set to zero here!
+#
+# But still ...
+let "f /= 0"
+#   let: f /= 0: division by 0 (error token is "0")
+# Expected behavior.
 
-    #  Bash (usually) sets the "integer value" of null to zero
-    #+ when performing an arithmetic operation.
-    #  But, don't try this at home, folks!
-    #  It's undocumented and probably non-portable behavior.
+#  Bash (usually) sets the "integer value" of null to zero
+#+ when performing an arithmetic operation.
+#  But, don't try this at home, folks!
+#  It's undocumented and probably non-portable behavior.
 
-    # Conclusion: Variables in Bash are untyped,
-    #+ with all attendant consequences.
+# Conclusion: Variables in Bash are untyped,
+#+ with all attendant consequences.
 
-    exit $?
+exit $?
+```
 
 Untyped variables are both a blessing and a curse.
 


### PR DESCRIPTION
Hi @deanboole:
範例 script 部份的程式區塊語法，從原本 "縮排4個空格"
改成 "不用縮排，而是在頭尾各加3個反引號(```)來包住，
並於開頭三個反引號後面明確標示使用 bash 語法標亮"。

個人覺得有語法標亮比較漂亮XD，
且這樣的 markdown 語法也比較正規一點。

Thx.
Goldie.