### PR TITLE
中文翻譯新增 ch3.md

### DIFF
--- a/content/ch3.md
+++ b/content/ch3.md
@@ -348,6 +348,7 @@ This is not portable behavior, and therefore not a recommended practice. In fact
 >`這並不是一個可以移植的行為，也因此並不推薦這樣的作法。事實上，近期所釋出的版本並不允許此種用法。雖然下劃線『_』卻能運行。`
 
 A colon can serve as a placeholder in an otherwise empty function.
+>`冒號可在其他的空白函數中作為佔位符。`
 ```
 not_empty ()
 {

--- a/content/ch3.md
+++ b/content/ch3.md
@@ -342,9 +342,10 @@ A colon is acceptable as a function name.
 :
 
 # The name of this function is :
+>`#此函數之名稱為『:』`
 ```
 This is not portable behavior, and therefore not a recommended practice. In fact, more recent releases of Bash do not permit this usage. An underscore _ works, though.
-
+>`這並不是一個可以移植的行為，也因此並不推薦這樣的作法。事實上，近期所釋出的版本並不允許此種用法。雖然下劃線『_』卻能運行。`
 
 A colon can serve as a placeholder in an otherwise empty function.
 ```


### PR DESCRIPTION
# The name of this function is :
>`#此函數之名稱為『:』`
```
This is not portable behavior, and therefore not a recommended practice. In fact, more recent releases of Bash do not permit this usage. An underscore _ works, though.
>`這並不是一個可以移植的行為，也因此並不推薦這樣的作法。事實上，近期所釋出的版本並不允許此種用法。雖然下劃線『_』卻能運行。`